### PR TITLE
Задача 6. Преобразование грамматики в ОНФХ

### DIFF
--- a/project/cfg_utils.py
+++ b/project/cfg_utils.py
@@ -1,0 +1,61 @@
+import json
+from os import PathLike
+
+import pyformlang.cfg
+
+__all__ = ["cfg_to_weak_normal_form", "json_to_cfg", "read_cfg"]
+
+
+def cfg_to_weak_normal_form(cfg: pyformlang.cfg.CFG) -> pyformlang.cfg.CFG:
+    # temporarily replace epsilon with a placeholder terminal
+    # so `to_normal_form()` works as `to_weak_normal_form()`
+    epsilon_placeholder = pyformlang.cfg.Terminal("CFG#EpsilonPlaceholder")
+    while epsilon_placeholder in cfg.terminals or epsilon_placeholder in cfg.variables:
+        epsilon_placeholder = pyformlang.cfg.Terminal(epsilon_placeholder.value + "_")
+    cfg = pyformlang.cfg.CFG(
+        start_symbol=cfg.start_symbol,
+        productions={
+            pyformlang.cfg.Production(
+                production.head,
+                [
+                    epsilon_placeholder
+                    if isinstance(cfg_object, pyformlang.cfg.Epsilon)
+                    else cfg_object
+                    for cfg_object in production.body
+                ]
+                if len(production.body) > 0
+                else [epsilon_placeholder],
+            )
+            for production in cfg.productions
+        },
+    )
+    cfg = cfg.to_normal_form()
+    return pyformlang.cfg.CFG(
+        start_symbol=cfg.start_symbol,
+        productions={
+            pyformlang.cfg.Production(
+                production.head,
+                [
+                    pyformlang.cfg.Epsilon()
+                    if cfg_object == epsilon_placeholder
+                    else cfg_object
+                    for cfg_object in production.body
+                ],
+            )
+            for production in cfg.productions
+        },
+    )
+
+
+def json_to_cfg(data: dict) -> pyformlang.cfg.CFG:
+    return pyformlang.cfg.CFG.from_text(
+        start_symbol=pyformlang.cfg.Variable(
+            data["start"] if "start" in data else None
+        ),
+        text=data["productions"] if "productions" in data else "",
+    )
+
+
+def read_cfg(path: PathLike) -> pyformlang.cfg.CFG:
+    with open(path, "r") as fs:
+        return json_to_cfg(json.load(fs))

--- a/tests/resources/test_cfg_utils/test_cfg_to_weak_normal_form.json
+++ b/tests/resources/test_cfg_utils/test_cfg_to_weak_normal_form.json
@@ -1,0 +1,89 @@
+[
+  {
+    "cfg": {},
+    "expected-result": {}
+  }, {
+  "cfg": {
+    "start": "S"
+  },
+  "expected-result": {
+    "start": "S"
+  }
+}, {
+  "cfg": {
+    "productions": "S -> a b"
+  },
+  "expected-result": {}
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> a b"
+  },
+  "expected-result": {
+    "start": "S",
+    "productions": "S -> \"VAR:a#CNF#\" \"VAR:b#CNF#\" \n \"VAR:a#CNF#\" -> a \n \"VAR:b#CNF#\" -> b"
+  }
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> A \n A -> a"
+  },
+  "expected-result": {
+    "start": "S",
+    "productions": "S -> a"
+  }
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> B \n B -> B"
+  },
+  "expected-result": {
+    "start": "S"
+  }
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> A b A \n A -> a | epsilon"
+  },
+  "expected-result": {
+    "start": "S",
+    "productions": "S -> A C#CNF#1 \n C#CNF#1 -> \"VAR:b#CNF#\" A \n A -> a | epsilon \n \"VAR:b#CNF#\" -> b"
+  }
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> S a S | epsilon"
+  },
+  "expected-result": {
+    "start": "S",
+    "productions": "S -> S C#CNF#1 | epsilon \n C#CNF#1 -> \"VAR:a#CNF#\" S \n \"VAR:a#CNF#\" -> a"
+  }
+}, {
+  "cfg": {
+    "start": "A",
+    "productions": "A -> B \n B -> C \n C -> D \n D -> a"
+  },
+  "expected-result": {
+    "start": "A",
+    "productions": "A -> a"
+  }
+}, {
+  "cfg": {
+    "start": "CFG#EpsilonPlaceholder",
+    "productions": "CFG#EpsilonPlaceholder -> A CFG#EpsilonPlaceholder_ \n A -> a | epsilon \n CFG#EpsilonPlaceholder_ -> b"
+  },
+  "expected-result": {
+    "start": "CFG#EpsilonPlaceholder",
+    "productions": "CFG#EpsilonPlaceholder -> A CFG#EpsilonPlaceholder_ \n A -> a | epsilon \n CFG#EpsilonPlaceholder_ -> b"
+  }
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> X | a b c d \n X -> a A \n A -> B | C | D \n B -> B \n C -> C c \n D -> a S | epsilon \n E -> e"
+  },
+  "expected-result": {
+    "start": "S",
+    "productions": "S -> \"VAR:a#CNF#\" A | \"VAR:a#CNF#\" C#CNF#1 \n A -> \"VAR:a#CNF#\" S | epsilon \n C#CNF#1 -> \"VAR:b#CNF#\" C#CNF#2 \n C#CNF#2 -> \"VAR:c#CNF#\" \"VAR:d#CNF#\" \n \"VAR:a#CNF#\" -> a \n \"VAR:b#CNF#\" -> b \n \"VAR:c#CNF#\" -> c \n \"VAR:d#CNF#\" -> d"
+  }
+}
+]

--- a/tests/test_cfg_utils.py
+++ b/tests/test_cfg_utils.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pyformlang.cfg
+import pytest
+
+from project.cfg_utils import cfg_to_weak_normal_form
+from project.cfg_utils import json_to_cfg
+from project.cfg_utils import read_cfg
+from tests.utils import assert_equal_cfgs
+
+
+# Not loading test data from json here because data loading itself is being tested
+# Otherwise test would have to reimplement tested function
+@pytest.mark.parametrize(
+    "input,expected_output",
+    [
+        ("{}", pyformlang.cfg.CFG()),
+        ('{"productions": ""}', pyformlang.cfg.CFG()),
+        (
+            '{"productions": "S -> a b"}',
+            pyformlang.cfg.CFG(
+                productions={
+                    pyformlang.cfg.Production(
+                        pyformlang.cfg.Variable("S"),
+                        [pyformlang.cfg.Terminal("a"), pyformlang.cfg.Terminal("b")],
+                    )
+                }
+            ),
+        ),
+        (
+            '{"start": "S"}',
+            pyformlang.cfg.CFG(start_symbol=pyformlang.cfg.Variable("S")),
+        ),
+        (
+            '{"start": "S", "productions": "S -> A b | epsilon \\n A -> a S a"}',
+            pyformlang.cfg.CFG(
+                start_symbol=pyformlang.cfg.Variable("S"),
+                productions={
+                    pyformlang.cfg.Production(
+                        pyformlang.cfg.Variable("S"),
+                        [pyformlang.cfg.Variable("A"), pyformlang.cfg.Terminal("b")],
+                    ),
+                    pyformlang.cfg.Production(
+                        pyformlang.cfg.Variable("S"), [pyformlang.cfg.Epsilon()]
+                    ),
+                    pyformlang.cfg.Production(
+                        pyformlang.cfg.Variable("A"),
+                        [
+                            pyformlang.cfg.Terminal("a"),
+                            pyformlang.cfg.Variable("S"),
+                            pyformlang.cfg.Terminal("a"),
+                        ],
+                    ),
+                },
+            ),
+        ),
+    ],
+)
+def test_read_cfg(input: str, expected_output: pyformlang.cfg.CFG, tmp_path: Path):
+    input_file_path = tmp_path / "cfg.json"
+    with open(input_file_path, "w") as fs:
+        fs.write(input)
+    actual_output = read_cfg(input_file_path)
+    assert_equal_cfgs(actual_output, expected_output)
+
+
+def test_cfg_to_weak_normal_form(config_data: dict):
+    assert_equal_cfgs(
+        cfg_to_weak_normal_form(json_to_cfg(config_data["cfg"])),
+        json_to_cfg(config_data["expected-result"]),
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 import networkx as nx
 import pydot
-import pyformlang.finite_automaton
+import pyformlang
 
 from project.fa_utils import graph_to_nfa
 
@@ -70,3 +70,11 @@ def assert_isomorphic_fas(
     assert_isomorphic_fa_to_graph(
         actual_fa, _fa_to_networkx_without_extra_starting_nodes(expected_fa)
     )
+
+
+def assert_equal_cfgs(
+    actual_cfg: pyformlang.cfg.CFG,
+    expected_cfg: pyformlang.cfg.CFG,
+):
+    assert actual_cfg.start_symbol == expected_cfg.start_symbol
+    assert actual_cfg.productions == expected_cfg.productions


### PR DESCRIPTION
# Задача 6. Преобразование грамматики в ОНФХ

* **Мягкий дедлайн**: 17.10.2021, 23:59
* **Жёсткий дедлайн**: 20.10.2021, 23:59
* Полный балл: 2

## Определение ОНФХ

Контекстно-свободная грамматика находится в ослабленной нормальной форме Хомского (ОНФХ) тогда и только тогда, когда все её правила имеют следующий вид
1. ```A -> B C```
2. ```A -> a```
3. ```A -> eps```

, где ```A, B, C``` -- произвольные нетерминалы, ```a``` -- произвольный терминал, ```eps```--- обозначение для эпсилон.

Отличия от нормальной формы Хомского (НФХ).
1. Эпсилон может выводиться из любого нетерминала.
2. Стартовый нетерминал может встречаться в правых частях правил.


## Задача

- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html) реализовать **функцию** преобразования контекстно-свободной грамматики в ослабленную нормальную форму Хомского (ОНФХ), но не классическую нормальную форму Хомского (НФХ). НФХ является частным случаем ОНФХ, а значит можно утверждать, что грамматика, находящаяся в НФХ находится и в ОНФХ. Но в данной задаче нас интересует максимально слабая форма, то есть ОНФХ, но не НФХ.
- [x] Предусмотреть возможность чтения грамматики из файла. Формат файла определяется возможностями pyformalng. Например, можно использовать [эту функцию](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html#pyformlang.cfg.CFG.from_text).
- [x] Добавить необходимые тесты.