### PR TITLE
Задача 7. Рекурсивные конечные автоматы

### DIFF
--- a/project/ecfg.py
+++ b/project/ecfg.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Dict
+
+import pyformlang.cfg
+
+__all__ = ["ECFG"]
+
+
+@dataclass
+class ECFG:
+    start_symbol: pyformlang.cfg.Variable
+    productions: Dict[pyformlang.cfg.Variable, pyformlang.regular_expression.Regex]
+
+    @staticmethod
+    def from_cfg(cfg: pyformlang.cfg.CFG) -> "ECFG":
+        new_productions: Dict[
+            pyformlang.cfg.Variable, pyformlang.regular_expression.Regex
+        ] = dict()
+        for production in cfg.productions:
+            regex = pyformlang.regular_expression.Regex(
+                " ".join(
+                    "$" if isinstance(obj, pyformlang.cfg.Epsilon) else obj.value
+                    for obj in production.body
+                )
+                if len(production.body) > 0
+                else "$"
+            )
+            new_productions[production.head] = (
+                new_productions[production.head].union(regex)
+                if production.head in new_productions
+                else regex
+            )
+        return ECFG(start_symbol=cfg.start_symbol, productions=new_productions)
+
+    @staticmethod
+    def from_data(data: dict):
+        return ECFG(
+            start_symbol=pyformlang.cfg.Variable(
+                data["start"] if "start" in data else None
+            ),
+            productions={
+                pyformlang.cfg.Variable(var): pyformlang.regular_expression.Regex(regex)
+                for var, regex in data["productions"].items()
+            }
+            if "productions" in data
+            else dict(),
+        )

--- a/project/rsm.py
+++ b/project/rsm.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from typing import Dict
+
+import pyformlang
+
+from project.ecfg import ECFG
+from project.fa_utils import nfa_from_data
+
+__all__ = ["RSM"]
+
+
+@dataclass
+class RSM:
+    start_symbol: pyformlang.cfg.Variable
+    boxes: Dict[pyformlang.cfg.Variable, pyformlang.finite_automaton.EpsilonNFA]
+
+    def minimize(self) -> "RSM":
+        minimized_rsm = RSM(start_symbol=self.start_symbol, boxes=dict())
+        for var, fa in self.boxes.items():
+            minimized_rsm.boxes[var] = fa.minimize()
+        return minimized_rsm
+
+    @staticmethod
+    def from_ecfg(ecfg: ECFG) -> "RSM":
+        return RSM(
+            start_symbol=ecfg.start_symbol,
+            boxes={
+                var: regex.to_epsilon_nfa() for var, regex in ecfg.productions.items()
+            },
+        )
+
+    @staticmethod
+    def from_data(data: dict) -> "RSM":
+        return RSM(
+            start_symbol=pyformlang.cfg.Variable(
+                data["start"] if "start" in data else None
+            ),
+            boxes={
+                pyformlang.cfg.Variable(var): nfa_from_data(fa)
+                for var, fa in data["boxes"].items()
+            }
+            if "boxes" in data
+            else dict(),
+        )

--- a/tests/resources/test_ecfg/test_factory_methods.json
+++ b/tests/resources/test_ecfg/test_factory_methods.json
@@ -1,0 +1,56 @@
+[
+  {
+    "cfg": {},
+    "ecfg": {}
+  }, {
+  "cfg": {
+    "start": "S"
+  },
+  "ecfg": {
+    "start": "S"
+  }
+}, {
+  "cfg": {
+    "productions": "S -> a b"
+  },
+  "ecfg": {
+    "productions": {
+      "S": "a b"
+    }
+  }
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> a b\nS -> a"
+  },
+  "ecfg": {
+    "start": "S",
+    "productions": {
+      "S": "a b|a"
+    }
+  }
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> a S b | epsilon"
+  },
+  "ecfg": {
+    "start": "S",
+    "productions": {
+      "S": "a S b|$"
+    }
+  }
+}, {
+  "cfg": {
+    "start": "S",
+    "productions": "S -> a A b | epsilon\n A -> a \n A -> S epsilon"
+  },
+  "ecfg": {
+    "start": "S",
+    "productions": {
+      "S": "a A b|$",
+      "A": "a|S $"
+    }
+  }
+}
+]

--- a/tests/resources/test_rsm/test_factory_methods.json
+++ b/tests/resources/test_rsm/test_factory_methods.json
@@ -1,0 +1,82 @@
+[
+  {
+    "ecfg": {},
+    "rsm": {}
+  }, {
+  "ecfg": {
+    "start": "S"
+  },
+  "rsm": {
+    "start": "S"
+  }
+}, {
+  "ecfg": {
+    "productions": {
+      "S": "a b"
+    }
+  },
+  "rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1;2; 0 -> 1 [label=a]; 1 -> 2 [label=b]}",
+        "start-states": ["0"],
+        "final-states": ["2"]
+      }
+    }
+  }
+}, {
+  "ecfg": {
+    "start": "S",
+    "productions": {
+      "S": "a A b|$",
+      "A": "a|S $"
+    }
+  },
+  "rsm": {
+    "start": "S",
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1;2;3; 0 -> 1 [label=a]; 1 -> 2 [label=A]; 2 -> 3 [label=b]}",
+        "start-states": ["0"],
+        "final-states": ["0", "3"]
+      },
+      "A": {
+        "graph": "digraph {0;1; 0 -> 1 [label=a]; 0 -> 1 [label=S]}",
+        "start-states": ["0"],
+        "final-states": ["1"]
+      }
+    }
+  }
+}, {
+  "ecfg": {
+    "start": "S",
+    "productions": {
+      "S": "a (b+b.c)*|$"
+    }
+  },
+  "rsm": {
+    "start": "S",
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1;2; 0 -> 1 [label=a]; 1 -> 2 [label=b]; 2 -> 2 [label=b]; 2 -> 1 [label=c];}",
+        "start-states": ["0"]
+      }
+    }
+  }
+}, {
+  "ecfg": {
+    "start": "S",
+    "productions": {
+      "S": ""
+    }
+  },
+  "rsm": {
+    "start": "S",
+    "boxes": {
+      "S": {
+        "graph": "digraph {}"
+      }
+    }
+  }
+}
+]

--- a/tests/resources/test_rsm/test_minimize.json
+++ b/tests/resources/test_rsm/test_minimize.json
@@ -1,0 +1,104 @@
+[
+  {
+    "rsm": {},
+    "minimized-rsm": {}
+  }, {
+  "rsm": {
+    "start": "S"
+  },
+  "minimized-rsm": {
+    "start": "S"
+  }
+}, {
+  "rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {}"
+      }
+    }
+  },
+  "minimized-rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {}"
+      }
+    }
+  }
+}, {
+  "rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1; 0 -> 1 [label=a]}",
+        "start-states": []
+      }
+    }
+  },
+  "minimized-rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {}"
+      }
+    }
+  }
+}, {
+  "rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1; 0 -> 1 [label=a]}",
+        "final-states": []
+      }
+    }
+  },
+  "minimized-rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {}"
+      }
+    }
+  }
+}, {
+  "rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1;2;3; 0 -> 1 [label=a]; 0 -> 2 [label=S]; 1 -> 3 [label=b]; 2 -> 3 [label=b]}",
+        "start-states": ["0"],
+        "final-states": ["3"]
+      }
+    }
+  },
+  "minimized-rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1;2; 0 -> 1 [label=a]; 0 -> 1 [label=S]; 1 -> 2 [label=b];}",
+        "start-states": ["0"],
+        "final-states": ["2"]
+      }
+    }
+  }
+}, {
+  "rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1;2;3; 0 -> 1 [label=a]; 0 -> 2 [label=A]; 1 -> 3 [label=b]; 2 -> 3 [label=b]}",
+        "start-states": ["0"],
+        "final-states": ["3"]
+      },
+      "A": {
+        "graph": "digraph {0;}"
+      }
+    }
+  },
+  "minimized-rsm": {
+    "boxes": {
+      "S": {
+        "graph": "digraph {0;1;2; 0 -> 1 [label=a]; 0 -> 1 [label=A]; 1 -> 2 [label=b];}",
+        "start-states": ["0"],
+        "final-states": ["2"]
+      },
+      "A": {
+        "graph": "digraph {0;}"
+      }
+    }
+  }
+}
+]

--- a/tests/test_ecfg.py
+++ b/tests/test_ecfg.py
@@ -1,0 +1,10 @@
+from project.cfg_utils import cfg_from_data
+from project.ecfg import ECFG
+from tests.utils import assert_definitely_equivalent_ecfgs
+
+
+def test_factory_methods(config_data: dict):
+    assert_definitely_equivalent_ecfgs(
+        ECFG.from_cfg(cfg_from_data(config_data["cfg"])),
+        ECFG.from_data(config_data["ecfg"]),
+    )

--- a/tests/test_rsm.py
+++ b/tests/test_rsm.py
@@ -1,0 +1,19 @@
+from project.ecfg import ECFG
+from project.rsm import RSM
+from tests.utils import assert_definitely_equivalent_rsms
+
+
+def test_factory_methods(config_data: dict):
+    assert_definitely_equivalent_rsms(
+        RSM.from_ecfg(ECFG.from_data(config_data["ecfg"])),
+        RSM.from_data(config_data["rsm"]),
+    )
+
+
+def test_minimize(config_data: dict):
+    actual_rsm = RSM.from_data(config_data["rsm"]).minimize()
+    expected_rsm = RSM.from_data(config_data["minimized-rsm"])
+    assert_definitely_equivalent_rsms(actual_rsm, expected_rsm)
+    for var, fa in actual_rsm.boxes.items():
+        assert fa.is_deterministic()
+        assert len(fa.states) == len(expected_rsm.boxes[var].states)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,16 @@
 import networkx as nx
 import pyformlang
 
+from project.ecfg import ECFG
+from project.rsm import RSM
+
 __all__ = [
     "assert_equivalent_fas",
     "assert_isomorphic_fa_to_graph",
     "assert_isomorphic_fas",
+    "assert_equivalent_regexes",
+    "assert_definitely_equivalent_ecfgs",
+    "assert_definitely_equivalent_rsms",
 ]
 
 
@@ -61,3 +67,26 @@ def assert_equal_cfgs(
 ):
     assert actual_cfg.start_symbol == expected_cfg.start_symbol
     assert actual_cfg.productions == expected_cfg.productions
+
+
+def assert_equivalent_regexes(
+    actual_regex: pyformlang.regular_expression.Regex,
+    expected_regex: pyformlang.regular_expression.Regex,
+):
+    assert_equivalent_fas(
+        actual_regex.to_epsilon_nfa(), expected_regex.to_epsilon_nfa()
+    )
+
+
+def assert_definitely_equivalent_ecfgs(actual_ecfg: ECFG, expected_ecfg: ECFG):
+    assert actual_ecfg.start_symbol == expected_ecfg.start_symbol
+    assert len(actual_ecfg.productions) == len(expected_ecfg.productions)
+    for variable, regex in expected_ecfg.productions.items():
+        assert_equivalent_regexes(actual_ecfg.productions[variable], regex)
+
+
+def assert_definitely_equivalent_rsms(actual_rsm: RSM, expected_rsm: RSM):
+    assert actual_rsm.start_symbol == expected_rsm.start_symbol
+    assert len(actual_rsm.boxes) == len(expected_rsm.boxes)
+    for variable, fa in expected_rsm.boxes.items():
+        assert_equivalent_fas(actual_rsm.boxes[variable], fa)


### PR DESCRIPTION
# Задача 7. Рекурсивные конечные автоматы

* **Мягкий дедлайн**: 30.10.2022, 23:59
* **Жёсткий дедлайн**: 02.11.2022, 23:59
* Полный балл: 5

## Расширенные контекстно-свободные грамматики (ECFG)

В дополнение к существующему в pyformalng формату описания КС грамматик зафиксируем следующий формат.
- Для каждого нетерминала существует ровно одно правило.
- На одной строке содержится ровно одно правило.
- Правило --- это нетерминал и регулярное выражение над терминалами и нетерминалами, принимаемое pyformalng, разделенные ``` -> ```. Например: ``` S -> a | b* S ```

Будем называть данный формат расширенными контекстно-свободными грамматиками (Extended Context-Free Grammars, ECFG).

## Задача

- [x] Реализовать тип для представления рекурсивных конечных автоматов. В качестве составных частей можно использовать типы из pyformlang (например, [конечные автоматы](https://pyformlang.readthedocs.io/en/latest/usage.html#finite-automata)). При проектировании этого типа необходимо помнить, что рекурсивные конечные автоматы будут использоваться в алгоритмах КС достижимости, основанных на линейной алгебре, а значит необходимо будет строить матрицы смежности. Здесь могут быть полезны результаты домашних работ по конечным автоматам.
- [x] Реализовать внутреннее представление для ECFG, пригодное как для дальнейшей конвертации в рекурсивный конечный автомат, так и для получения его из "внешних источников", таких, например, как преобразование из стандартного внутреннего представления КС грамматик в pyformlang.
- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html), реализовать **функцию** преобразования контекстно-свободной грамматики в стандартном формате pyformlang в ECFG.
  - Предусмотреть возможность получать исходную грамматику из различных источников. Например, прочитать из файла или получить из преобразования в ОНФХ.
- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html), [регулярными выражениями](https://pyformlang.readthedocs.io/en/latest/usage.html#regular-expression) и [конечными автоматами](https://pyformlang.readthedocs.io/en/latest/usage.html#finite-automata), реализовать **функцию** преобразования контекстно-свободной грамматики в ECFG в рекурсивный конечный автомат.
  - Предусмотреть возможность получать исходную грамматику из различных источников. Например, прочитать из файла, прочитать из строковой переменной, получить как результат работы какой-либо другой процедуры.
- [x] Реализовать **функцию** минимизации рекурсивного конечного автомата. Здесь под минимизацией понимается минимизация автомата для каждого нетерминала как конечного автомата над смешанным алфавитом.
- [x] Добавить необходимые тесты.